### PR TITLE
List MFA devices only for the current user

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ wev aws s3 ls
 
 ```text
 Resolving AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_SESSION_TOKEN...
-We need your token.
+Please enter your MFA token to authenticate.
 
 Token:
 ```
@@ -96,10 +96,13 @@ There are two optional properties:
     "Statement": [
         {
             "Action": [
+                "iam:GetUser",
                 "iam:ListMFADevices"
             ],
             "Effect": "Allow",
-            "Resource": "*"
+            "Resource": [
+                "arn:aws:iam::*:user/${aws:username}"
+            ]
         },
         {
             "Action": "s3:ListAllMyBuckets",

--- a/wev_awsmfa/plugin.py
+++ b/wev_awsmfa/plugin.py
@@ -3,7 +3,11 @@ from typing import List, Optional
 
 from wev.sdk import PluginBase, Resolution, ResolutionSupport
 
-from wev_awsmfa.aws import discover_mfa_device_arn, get_session_token
+from wev_awsmfa.aws import (
+    discover_mfa_device_arn,
+    discover_user_name,
+    get_session_token,
+)
 
 
 class Plugin(PluginBase):
@@ -43,12 +47,19 @@ class Plugin(PluginBase):
         """
         mfa_device_arn = self.get_mfa_device(logger=support.logger)
         if not mfa_device_arn:
-            mfa_device_arn = discover_mfa_device_arn(logger=support.logger)
+            username = discover_user_name(logger=support.logger)
+            mfa_device_arn = discover_mfa_device_arn(
+                logger=support.logger,
+                username=username,
+            )
         response = get_session_token(
             logger=support.logger,
             duration=self.get_duration(logger=support.logger),
             serial=mfa_device_arn,
-            token=support.confidential_prompt("We need your token.", "Token:"),
+            token=support.confidential_prompt(
+                "Please enter your MFA token to authenticate.",
+                "Token:",
+            ),
         )
 
         return Resolution.make(value=response[0], expires_at=response[1])

--- a/wev_awsmfa/test_plugin.py
+++ b/wev_awsmfa/test_plugin.py
@@ -51,6 +51,12 @@ def discover_mfa_device_arn() -> Iterable[Mock]:
 
 
 @fixture
+def discover_user_name() -> Iterable[Mock]:
+    with patch("wev_awsmfa.plugin.discover_user_name", return_value="bob") as patched:
+        yield patched
+
+
+@fixture
 def get_session_token() -> Iterable[Mock]:
     response = (
         ("alpha", "beta", "gamma"),
@@ -68,6 +74,7 @@ def resolution_make() -> Iterable[Mock]:
 
 def test_resolve(
     discover_mfa_device_arn: Mock,
+    discover_user_name: Mock,
     get_session_token: Mock,
     resolution_make: Mock,
 ) -> None:


### PR DESCRIPTION
- Improves UI messages.
- Improves error handling.
- Updates example policy to restrict MFA listing to only the current user.
- Lists MFA devices only for the current user.